### PR TITLE
Skip reading cells that start with %%

### DIFF
--- a/ipynb/utils.py
+++ b/ipynb/utils.py
@@ -79,7 +79,9 @@ def code_from_ipynb(nb, markdown=False):
     for cell in nb['cells']:
         if cell['cell_type'] == 'code':
             # transform the input to executable Python
-            code += ''.join(cell['source'])
+            # skip cells that start with %% because they might not even contain Python code
+            if len(cell['source']) > 0 and len(cell['source'][0]) >= 2 and cell['source'][0][:2] != '%%':
+                code += ''.join(cell['source'])
         if cell['cell_type'] == 'markdown':
             code += '\n# ' + '# '.join(cell['source'])
         # We want a blank newline after each cell's output.


### PR DESCRIPTION
Cell magics might not even contain Python code so the entire cell should be ignored if it starts with %%.  Another fork of the parent repo (https://github.com/kuuurt/ipynb/commit/640001d281e982a44bc21a892dfc72ed83b336cb) removes lines that contain %% but that would still try to parse the other lines in the cell which might cause a syntax error if the cell contained non-Python code.